### PR TITLE
ES-48266: fix date crash for language except english

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,8 @@ class Kronos extends Component {
   }
 
   save(saving) {
-    const { datetime } = this.state
+    let { datetime } = this.state
+    datetime = datetime || Moment();
     if (typeof this.props.date !== 'undefined') {
       saving.hours(datetime.hours())
       saving.minutes(datetime.minutes())
@@ -301,7 +302,7 @@ class Kronos extends Component {
       this.toggle(false)
       if (this.props.onBlur) this.props.onBlur(e)
     }
-    if (this.state.input == this.state.datetime.format(this.format())) {
+    if (this.state.input == datetime.format(this.format())) {
       return
     } else {
       datetime = this.parse(this.state.input)


### PR DESCRIPTION
ES-48266
DatePicker crashed for values other than english. Add a fallback as Moment object to prevent crash.

Dashboard PR:
https://github.com/locus-taxy/locus-dashboard-v2/pull/5113