### PR TITLE
ES-53453 - add portal support

### DIFF
--- a/.changeset/violet-lemons-exercise.md
+++ b/.changeset/violet-lemons-exercise.md
@@ -1,0 +1,5 @@
+---
+"@locus-taxy/react-kronos": minor
+---
+
+Portal support

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^1.0.0",
+    "@floating-ui/react-dom-interactions": "^0.9.3",
     "classnames": "^2.2.5",
     "color": "^0.11.4",
     "jss": "^6.5.0",

--- a/src/floating-container.js
+++ b/src/floating-container.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { autoUpdate, flip, useFloating } from "@floating-ui/react-dom";
+
+const FloatingContainer = ({ children }) => {
+  const { x, y, reference, floating, strategy } = useFloating({
+    middleware: [flip()],
+    placement: 'bottom-start',
+    whileElementsMounted: autoUpdate
+  });
+
+  return <>{children({ x, y, reference, floating, strategy })}</>;
+};
+
+export default FloatingContainer;

--- a/src/floating-container.js
+++ b/src/floating-container.js
@@ -8,7 +8,7 @@ const FloatingContainer = ({ children }) => {
     whileElementsMounted: autoUpdate
   });
 
-  return <>{children({ x, y, reference, floating, strategy })}</>;
+  return children({ x, y, reference, floating, strategy });
 };
 
 export default FloatingContainer;

--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,8 @@ class Kronos extends Component {
     preventClickOnDateTimeOutsideRange: false,
     visible: false,
     disabled: false,
-    portal: false,
     theme: {},
+    portal: false
   };
 
   static above = false
@@ -407,9 +407,13 @@ class Kronos extends Component {
   }
 
   renderInput(reference) {
-    const inputClasses = cn(this.props.inputClassName, this.props.theme.input, {
-      "outside-range": this.state.dateTimeExceedsValidRange,
-    });
+    const inputClasses = cn(
+      this.props.inputClassName,
+      this.props.theme.input, 
+      {
+        "outside-range": this.state.dateTimeExceedsValidRange,
+      }
+    );
 
     return (
       <input

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ class Kronos extends Component {
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
     theme: PropTypes.object,
-    renderOnPortal: PropTypes.bool,
+    portal: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -92,7 +92,7 @@ class Kronos extends Component {
     preventClickOnDateTimeOutsideRange: false,
     visible: false,
     disabled: false,
-    renderOnPortal: false,
+    portal: false,
     theme: {},
   };
 
@@ -476,7 +476,7 @@ class Kronos extends Component {
       }
     );
 
-    if (this.props.renderOnPortal) {
+    if (this.props.portal) {
       return (
         <FloatingContainer>
           {({ x, y, reference, floating, strategy }) => (

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import Moment from 'moment'
+import { FloatingPortal } from "@floating-ui/react-dom-interactions";
 
 import cn from 'classnames'
 
 import { Keys, Levels, Units, Types } from './constants'
 import Calendar from './calendar'
+import FloatingContainer from './floating-container'
 
 const ISOregex = /((\d{4}\-\d\d\-\d\d)[tT]([\d:\.]*)?)([zZ]|([+\-])(\d\d):?(\d\d))/
 const minutesOfDay = m => {
@@ -78,8 +80,9 @@ class Kronos extends Component {
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
-    theme: PropTypes.object
-  }
+    theme: PropTypes.object,
+    renderOnPortal: PropTypes.bool,
+  };
 
   static defaultProps = {
     closeOnSelect: true,
@@ -89,8 +92,9 @@ class Kronos extends Component {
     preventClickOnDateTimeOutsideRange: false,
     visible: false,
     disabled: false,
-    theme: {}
-  }
+    renderOnPortal: false,
+    theme: {},
+  };
 
   static above = false
 
@@ -402,64 +406,108 @@ class Kronos extends Component {
     }
   }
 
+  renderInput(reference) {
+    const inputClasses = cn(this.props.inputClassName, this.props.theme.input, {
+      "outside-range": this.state.dateTimeExceedsValidRange,
+    });
+
+    return (
+      <input
+        type="text"
+        id={this.props.inputId}
+        ref={(input) => {
+          this._input = input;
+          reference?.(input);
+        }}
+        value={this.state.input || ""}
+        onClick={::this.onClickInput}
+        onFocus={::this.onFocusInput}
+        onBlur={::this.onBlurInput}
+        onKeyDown={(e) => this.onKeyDown(e.keyCode)}
+        onChange={::this.onChangeInput}
+        placeholder={this.props.placeholder}
+        name={this.props.name}
+        className={inputClasses}
+        disabled={this.props.disabled}
+        style={this.props.inputStyle}
+      />
+    );
+  }
+
+  renderCalendar() {
+    const visible = this.props.controlVisibility
+      ? this.props.visible
+      : this.state.visible;
+
+    if (!visible) {
+      return null;
+    }
+
+    return (
+      <Calendar
+        instance={this.props.instance}
+        datetime={this.state.datetime}
+        onSelect={::this.onSelect}
+        above={(bool) =>
+          typeof bool === "undefined" ? this.above : (this.above = bool)
+        }
+        level={this.state.level}
+        setLevel={(level) => this.setState({ level })}
+        validate={::this.validate}
+        options={this.props.options}
+        inputRect={this._input.getClientRects()[0]}
+        hideOutsideDateTimes={this.props.hideOutsideDateTimes}
+        timeStep={this.props.timeStep}
+        style={this.props.calendarStyle}
+        className={this.props.calendarClassName}
+        theme={this.props.theme}
+      />
+    );
+  }
+
   render() {
     const mainClasses = cn(
-      'react-kronos',
+      "react-kronos",
       this.props.className,
       this.props.instance,
       this.props.theme.kronos,
       {
-        [this.props.theme.kronosDisabled]: this.props.disabled
+        [this.props.theme.kronosDisabled]: this.props.disabled,
       }
-    )
-    const inputClasses = cn(
-      this.props.inputClassName,
-      this.props.theme.input,
-      { 'outside-range': this.state.dateTimeExceedsValidRange },
-    )
-    const visible = this.props.controlVisibility
-      ? this.props.visible
-      : this.state.visible
+    );
+
+    if (this.props.renderOnPortal) {
+      return (
+        <FloatingContainer>
+          {({ x, y, reference, floating, strategy }) => (
+            <div className={mainClasses} data-toolbox="kronos">
+              {this.renderInput(reference)}
+              <FloatingPortal>
+                <div
+                  ref={floating}
+                  style={{
+                    position: strategy,
+                    top: y ?? 0,
+                    left: x ?? 0,
+                    zIndex: 5001,
+                  }}
+                >
+                  {this.renderCalendar()}
+                </div>
+              </FloatingPortal>
+            </div>
+          )}
+        </FloatingContainer>
+      );
+    }
+
     return (
       <div className={mainClasses} data-toolbox="kronos">
-        <input
-          type="text"
-          id={this.props.inputId}
-          ref={input => (this._input = input)}
-          value={this.state.input || ''}
-          onClick={::this.onClickInput}
-          onFocus={::this.onFocusInput}
-          onBlur={::this.onBlurInput}
-          onKeyDown={e => this.onKeyDown(e.keyCode)}
-          onChange={::this.onChangeInput}
-          placeholder={this.props.placeholder}
-          name={this.props.name}
-          className={inputClasses}
-          disabled={this.props.disabled}
-          style={this.props.inputStyle}
-        />
-        {visible &&
-          <Calendar
-            instance={this.props.instance}
-            datetime={this.state.datetime}
-            onSelect={::this.onSelect}
-            above={bool =>
-              typeof bool === 'undefined' ? this.above : (this.above = bool)}
-            level={this.state.level}
-            setLevel={level => this.setState({ level })}
-            validate={::this.validate}
-            options={this.props.options}
-            inputRect={this._input.getClientRects()[0]}
-            hideOutsideDateTimes={this.props.hideOutsideDateTimes}
-            timeStep={this.props.timeStep}
-            style={this.props.calendarStyle}
-            className={this.props.calendarClassName}
-            theme={this.props.theme}
-          />}
+        {this.renderInput()}
+        {this.renderCalendar()}
       </div>
-    )
+    );
   }
 }
-
 
 export default Kronos;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,33 @@
     human-id "^1.0.2"
     prettier "^1.19.1"
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.1.tgz#3321d4e799d6ac2503e729131d07ad0e714aabeb"
+  integrity sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
+"@floating-ui/react-dom-interactions@^0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.9.3.tgz#4d4d81664066ac36980e50691aa90b1d40667949"
+  integrity sha512-oHwFLxySRtmhgwg7ZdWswvDDi+ld4mEtxu6ngOd7mRC5L1Rk6adjSfOBOHDxea+ItAWmds8m6A725sn1HQtUyQ==
+  dependencies:
+    "@floating-ui/react-dom" "^1.0.0"
+    aria-hidden "^1.1.3"
+
+"@floating-ui/react-dom@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.0.0.tgz#e0975966694433f1f0abffeee5d8e6bb69b7d16e"
+  integrity sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
@@ -1370,6 +1397,13 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-hidden@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.1.tgz#ad8c1edbde360b454eb2bf717ea02da00bfee0f8"
+  integrity sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==
+  dependencies:
+    tslib "^2.0.0"
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -2981,6 +3015,11 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+tslib@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tty-table@^2.8.10:
   version "2.8.13"


### PR DESCRIPTION
Added the `portal` support, so now the `Calender` component popover will render in the `body` with the help of `floating-ui` library. The change is made since the current way of rendering has some UX issues when we are using it in modals. 