### PR TITLE
feat: add `portal` class when portal is enabled

### DIFF
--- a/.changeset/wild-ladybugs-lay.md
+++ b/.changeset/wild-ladybugs-lay.md
@@ -1,0 +1,5 @@
+---
+"@locus-taxy/react-kronos": patch
+---
+
+add portal class when portal is enabled

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -29,6 +29,7 @@ class Calendar extends Component {
     setLevel: PropTypes.func.isRequired,
     onMouseDown: PropTypes.func,
     onMouseUp: PropTypes.func,
+    portal: PropTypes.bool,
   }
 
   static _isMounted = false
@@ -266,7 +267,11 @@ class Calendar extends Component {
 
     return (
       <div
-        className={cn(this.props.className, calendarClass)}
+        className={cn(
+          this.props.className,
+          calendarClass,
+          this.props.portal ? theme.portal : ""
+        )}
         onMouseDown={e => this.props.above(true)}
         onMouseUp={e => this.props.above(false)}
         style={this.props.style}

--- a/src/index.js
+++ b/src/index.js
@@ -465,6 +465,7 @@ class Kronos extends Component {
         style={this.props.calendarStyle}
         className={this.props.calendarClassName}
         theme={this.props.theme}
+        portal={this.props.portal}
       />
     );
   }


### PR DESCRIPTION
Updated the `Calendar` component to receive `portal` prop and prefix `.portal` class to it conditionally. 